### PR TITLE
adding globals support in native interface

### DIFF
--- a/cli/modules/std_math.c
+++ b/cli/modules/std_math.c
@@ -8,12 +8,8 @@
 
 #include <math.h>
 
-// M_PI is non standard. The macro _USE_MATH_DEFINES defining before importing
-// <math.h> will define the constants for MSVC. But for a portable solution,
-// we're defining it ourselves if it isn't already.
-#ifndef M_PI
-  #define M_PI 3.14159265358979323846
-#endif
+// M_PI is non standard. For a portable solution, we're defining it ourselves.
+#define PK_PI 3.14159265358979323846
 
 DEF(stdMathFloor,
   "floor(value:num) -> num\n") {
@@ -187,6 +183,12 @@ void registerModuleMath(PKVM* vm) {
 
   PkHandle* math = pkNewModule(vm, "math");
 
+  // Set global value PI.
+  pkReserveSlots(vm, 2);
+  pkSetSlotHandle(vm, 0, math);  // slot[0]    = math
+  pkSetSlotNumber(vm, 1, PK_PI); // slot[1]    = 3.14
+  pkSetGlobal(vm, 0, 1, "PI");   // slot[0].PI = slot[1]
+
   pkModuleAddFunction(vm, math, "floor",  stdMathFloor,      1);
   pkModuleAddFunction(vm, math, "ceil",   stdMathCeil,       1);
   pkModuleAddFunction(vm, math, "pow",    stdMathPow,        2);
@@ -204,14 +206,6 @@ void registerModuleMath(PKVM* vm) {
   pkModuleAddFunction(vm, math, "atan",   stdMathArcTangent, 1);
   pkModuleAddFunction(vm, math, "log10",  stdMathLog10,      1);
   pkModuleAddFunction(vm, math, "round",  stdMathRound,      1);
-
-  // FIXME:
-  // Refactor native type interface and add PI as a global to the module.
-  //
-  // Note that currently it's mutable (since it's a global variable, not
-  // constant and pocketlang doesn't support constant) so the user shouldn't
-  // modify the PI, like in python.
-  //pkModuleAddGlobal(vm, math, "PI", Handle-Of-PI);
 
   pkRegisterModule(vm, math);
   pkReleaseHandle(vm, math);

--- a/src/include/pocketlang.h
+++ b/src/include/pocketlang.h
@@ -348,7 +348,11 @@ PK_PUBLIC void pkSetSlotStringLength(PKVM* vm, int index,
 // Set the [index] slot's value as the given [handle]. The function won't
 // reclaim the ownership of the handle and you can still use it till
 // it's released by yourself.
-PK_PUBLIC void PkSetSlotHandle(PKVM* vm, int index, PkHandle* handle);
+PK_PUBLIC void pkSetSlotHandle(PKVM* vm, int index, PkHandle* handle);
+
+// Assign a global variable to a module at [module] slot, with the value at the
+// [global] slot with the given [name].
+PK_PUBLIC void pkSetGlobal(PKVM* vm, int module, int global, const char* name);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/pk_value.c
+++ b/src/pk_value.c
@@ -389,7 +389,7 @@ Upvalue* newUpvalue(PKVM* vm, Var* value) {
 }
 
 Fiber* newFiber(PKVM* vm, Closure* closure) {
-  ASSERT(closure->fn->arity >= -1, OOPS);
+  ASSERT(closure == NULL || closure->fn->arity >= -1, OOPS);
 
   Fiber* fiber = ALLOCATE(vm, Fiber);
 
@@ -401,11 +401,13 @@ Fiber* newFiber(PKVM* vm, Closure* closure) {
   fiber->state = FIBER_NEW;
   fiber->closure = closure;
 
-  if (closure->fn->is_native) {
+  if (closure == NULL || closure->fn->is_native) {
     // For native functions, we're only using stack for parameters,
     // there won't be any locals or temps (which are belongs to the
     // native "C" stack).
-    int stack_size = utilPowerOf2Ceil(closure->fn->arity + 1);
+
+    int stack_size = (closure == NULL) ? 1 : closure->fn->arity + 1;
+    stack_size = utilPowerOf2Ceil(stack_size);
 
     // We need at least 1 stack slot for the return value.
     if (stack_size == 0) stack_size++;

--- a/tests/examples/pi.pk
+++ b/tests/examples/pi.pk
@@ -3,11 +3,7 @@
 ##
 ## PI/4 = 1 - 1/3 + 1/5 - 1/7 + 1/9 - ...
 
-from math import abs
-
-## Temproarly we cannot register variables on native modules
-## will be implemented soon. So defining the PI here.
-PI = 3.14159265358979323846
+from math import abs, PI
 
 pi_by_4 = 0; sign = -1
 for i in 1..100000

--- a/tests/modules/math.pk
+++ b/tests/modules/math.pk
@@ -7,18 +7,13 @@ from math import abs, round, log10,
 
 assert(ceil(1.1) == floor(2.9))
 
-## FIXME:
-## temproarly modules cannot define globals via native interface
-## and it'll be fixed soon.
-PI = 3.14159265358979323846
-
 assert(m.sin(0) == 0)
-assert(m.sin(PI/2) == 1)
+assert(m.sin(m.PI/2) == 1)
 
 threshold = 0.0000000000001
 
-assert(abs(m.cos(PI/3) - 0.5) < threshold )
-assert(abs(m.tan(PI/4) - 1.0) < threshold )
+assert(abs(m.cos(m.PI/3) - 0.5) < threshold )
+assert(abs(m.tan(m.PI/4) - 1.0) < threshold )
 for i in 0..1000
   assert(abs(m.sin(i) / m.cos(i) - m.tan(i)) < threshold)
 end
@@ -29,8 +24,8 @@ for i in 0..100
   assert(abs(m.sinh(i) / m.cosh(i) - m.tanh(i)) < threshold)
 end
 
-assert(abs(m.acos(PI/4) - 0.5) < 0.35)
-assert(abs(m.atan(PI/4) - 0.5) < 0.2)
+assert(abs(m.acos(m.PI/4) - 0.5) < 0.35)
+assert(abs(m.atan(m.PI/4) - 0.5) < 0.2)
 
 assert((m.acos(0.5) - 1.1276259652063807) < threshold)
 assert((m.atan(0.3) - 1.1276259652063807) < threshold)


### PR DESCRIPTION
`pkSetGlobal` function was implemented to support adding globals from the native interface. Also, the PKVM slots don't need a runtime anymore to use them (see math.PI global to see how it works).