### PR TITLE
[Enhancement] Add List.join(sep="") method.

### DIFF
--- a/tests/lang/basics.pk
+++ b/tests/lang/basics.pk
@@ -33,6 +33,8 @@ l1 = [] + [1]; assert(l1.length == 1); assert(l1[0] == 1)
 l1 = [1] + []; assert(l1.length == 1); assert(l1[0] == 1)
 l2 = l1 + [1,2,3]; assert(l2.length == 4); assert(l2 == [1,1,2,3])
 l3 = l2 + l1 + l2; assert(l3 == [1,1,2,3,1,1,1,2,3])
+assert(l3.join() == '112311123')
+assert(l3.join(',') == '1,1,2,3,1,1,1,2,3')
 
 ## list references are shared.
 l1 = [1];l2 = l1;l1 += [2]


### PR DESCRIPTION
Also add separator as an optional argument to builtin list_join().

```[1, 2, 3].join(',') ``` looks better than ```list_join([1, 2, 3], ',')```.
However, list_join() is used in string interpolation, and builtin function is faster than method call.
So keep builtin list_join() but add a new method to List class.

Example:
```ruby
print([1, 2, 3].join())
print([1, 2, 3].join(', '))
```

Output:
```
123
1, 2, 3
```