### PR TITLE
[Enhancement] Add Map.length, Map.keys, Map.values.

### DIFF
--- a/src/core/core.c
+++ b/src/core/core.c
@@ -1997,7 +1997,37 @@ Var varGetAttrib(PKVM* vm, Var on, String* attrib) {
     } break;
 
     case OBJ_MAP: {
-      // TODO:
+      Map* map = (Map*)obj;
+      switch (attrib->hash) {
+
+        case CHECK_HASH("length", 0x83d03615):
+          return VAR_NUM((double)(map->count));
+
+        case CHECK_HASH("keys", 0xF94A08CD): {
+          List* list = newList(vm, map->count);
+          vmPushTempRef(vm, &list->_super); // list.
+          for (uint32_t i = 0; i < map->capacity; i++) {
+            if (!IS_UNDEF(map->entries[i].key)) {
+              listAppend(vm, list, map->entries[i].key);
+            }
+          }
+          vmPopTempRef(vm); // list.
+          return VAR_OBJ(list);
+        }
+
+        case CHECK_HASH("values", 0x34474C3B): {
+          List* list = newList(vm, map->count);
+          vmPushTempRef(vm, &list->_super); // list.
+          for (uint32_t i = 0; i < map->capacity; i++) {
+            if (!IS_UNDEF(map->entries[i].key)) {
+              listAppend(vm, list, map->entries[i].value);
+            }
+          }
+          vmPopTempRef(vm); // list.
+          return VAR_OBJ(list);
+        }
+
+      } // switch
     } break;
 
     case OBJ_RANGE: {

--- a/tests/lang/basics.pk
+++ b/tests/lang/basics.pk
@@ -39,6 +39,14 @@ l1 = [1];l2 = l1;l1 += [2]
 assert(l2[1] == 2)
 assert(l1 == l2)
 
+## Maps test.
+m = {1: '1', '2': 2, 'foo': 'bar', 3: 3}
+m[1..2] = fn end
+assert(m.keys.length == m.length)
+assert(m.values.length == m.length)
+keys = m.keys; values = m.values
+for i in 0..keys.length do assert(m[keys[i]] == values[i]) end
+
 ## in tests.
 assert(!('abc' in 'a'))
 assert(42 in [12, 42, 3.14])


### PR DESCRIPTION
Example: 
```ruby
m = {1: 'dog', 2: 'cat', 3: 'rabbit'}
print(m.length)
print(m.keys)
print(m.values)
```
Output:
```
3
[2, 1, 3]
["cat", "dog", "rabbit"]
```