### PR TITLE
[Bugfix] fix pkIsSlotInstanceOf bug

### DIFF
--- a/src/core/public.c
+++ b/src/core/public.c
@@ -714,7 +714,8 @@ bool pkIsSlotInstanceOf(PKVM* vm, int inst, int cls, bool* val) {
   VALIDATE_SLOT_INDEX(inst);
   VALIDATE_SLOT_INDEX(cls);
 
-  *val = varIsType(vm, inst, cls);
+  Var instance = ARG(inst), class_ = SLOT(cls);
+  *val = varIsType(vm, instance, class_);
   return !VM_HAS_ERROR(vm);
 }
 


### PR DESCRIPTION
C interface `pkIsSlotInstanceOf` is not working. This is a fix.