### PR TITLE
[Enhancement] add experimental error handling: Fiber.try() and built-in raise()

### DIFF
--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -28,8 +28,9 @@ TEST_SUITE = {
     "lang/fibers.pk",
     "lang/functions.pk",
     "lang/import.pk",
+    "lang/try.pk",
   ),
-  
+
   "Modules Test" : (
     "modules/dummy.pk",
     "modules/math.pk",
@@ -65,7 +66,7 @@ def main():
 def run_all_tests():
   ## get the interpreter.
   pocket = get_pocket_binary()
-  
+
   for suite in TEST_SUITE:
     print_title(suite)
     for test in TEST_SUITE[suite]:
@@ -142,7 +143,7 @@ def print_title(title):
   print("----------------------------------")
   print(" %s " % title)
   print("----------------------------------")
-  
+
 if __name__ == '__main__':
   ## This will enable ANSI codes in windows terminal.
   os.system('')

--- a/src/core/debug.c
+++ b/src/core/debug.c
@@ -222,7 +222,14 @@ void reportRuntimeError(PKVM* vm, Fiber* fiber, bool* is_first) {
   // Error message.
   if (*is_first) {
     _printRed(vm, "Error: ");
-    writefn(vm, fiber->error->data);
+    String* msg = NULL;
+    if (IS_OBJ_TYPE(fiber->error, OBJ_STRING)) {
+      msg = (String*)AS_OBJ(fiber->error);
+    } else {
+      msg = varToString(vm, fiber->error, false);
+    }
+
+    writefn(vm, msg->data);
     writefn(vm, "\n");
     *is_first = false;
   }

--- a/src/core/debug.c
+++ b/src/core/debug.c
@@ -214,15 +214,18 @@ static void _reportStackFrame(PKVM* vm, CallFrame* frame) {
   }
 }
 
-void reportRuntimeError(PKVM* vm, Fiber* fiber) {
+void reportRuntimeError(PKVM* vm, Fiber* fiber, bool* is_first) {
 
   pkWriteFn writefn = vm->config.stderr_write;
   if (writefn == NULL) return;
 
   // Error message.
-  _printRed(vm, "Error: ");
-  writefn(vm, fiber->error->data);
-  writefn(vm, "\n");
+  if (*is_first) {
+    _printRed(vm, "Error: ");
+    writefn(vm, fiber->error->data);
+    writefn(vm, "\n");
+    *is_first = false;
+  }
 
   // If the stack frames are greater than 2 * max_dump_frames + 1,
   // we're only print the first [max_dump_frames] and last [max_dump_frames]

--- a/src/core/debug.h
+++ b/src/core/debug.h
@@ -18,7 +18,7 @@ void reportCompileTimeError(PKVM* vm, const char* path, int line,
                             const char* fmt, va_list args);
 
 // Pretty print runtime error.
-void reportRuntimeError(PKVM* vm, Fiber* fiber);
+void reportRuntimeError(PKVM* vm, Fiber* fiber, bool* first);
 
 // Dump opcodes of the given function to the stdout.
 void dumpFunctionCode(PKVM* vm, Function* func);

--- a/src/core/value.c
+++ b/src/core/value.c
@@ -233,8 +233,8 @@ static void popMarkedObjectsInternal(Object* obj, PKVM* vm) {
 
       markObject(vm, &fiber->caller->_super);
       markObject(vm, &fiber->native->_super);
-      markObject(vm, &fiber->error->_super);
 
+      markValue(vm, fiber->error);
       markValue(vm, fiber->self);
 
     } break;
@@ -495,6 +495,7 @@ Fiber* newFiber(PKVM* vm, Closure* closure) {
 
   fiber->open_upvalues = NULL;
   fiber->self = VAR_UNDEFINED;
+  fiber->error = VAR_NULL;
 
   // Initialize the return value to null (doesn't really have to do that here
   // but if we're trying to debut it may crash when dumping the return value).
@@ -1127,7 +1128,7 @@ Var mapRemoveKey(PKVM* vm, Map* self, Var key) {
 }
 
 bool fiberHasError(Fiber* fiber) {
-  return fiber->error != NULL;
+  return fiber->error != VAR_NULL;
 }
 
 void freeObject(PKVM* vm, Object* self) {

--- a/src/core/value.h
+++ b/src/core/value.h
@@ -516,7 +516,7 @@ struct Fiber {
   Fiber *caller, *native;
 
   // Runtime error initially NULL, heap allocated.
-  String* error;
+  Var error;
 };
 
 struct Class {

--- a/src/core/value.h
+++ b/src/core/value.h
@@ -471,6 +471,8 @@ typedef enum {
 struct Fiber {
   Object _super;
 
+  bool trying;
+
   FiberState state;
 
   // The root closure of the fiber.

--- a/src/core/vm.h
+++ b/src/core/vm.h
@@ -47,6 +47,9 @@
     (vm->fiber->error = VAR_OBJ(err)); \
   } while (false)
 
+// Reset the error of the current fiber.
+#define VM_RESET_ERROR(vm) (vm->fiber->error = VAR_NULL)
+
 // A doubly link list of vars that have reference in the host application.
 // Handles are wrapper around Var that lives on the host application.
 struct PkHandle {

--- a/src/core/vm.h
+++ b/src/core/vm.h
@@ -132,6 +132,9 @@ struct PKVM {
 
   // Current fiber.
   Fiber* fiber;
+
+  // The fiber that error occured.
+  Fiber* perpetrator;
 };
 
 // A realloc() function wrapper which handles memory allocations of the VM.

--- a/src/core/vm.h
+++ b/src/core/vm.h
@@ -38,13 +38,13 @@
 #define HEAP_FILL_PERCENT 75
 
 // Evaluated to "true" if a runtime error set on the current fiber.
-#define VM_HAS_ERROR(vm) (vm->fiber->error != NULL)
+#define VM_HAS_ERROR(vm) (vm->fiber->error != VAR_NULL)
 
 // Set the error message [err] to the [vm]'s current fiber.
 #define VM_SET_ERROR(vm, err)        \
   do {                               \
     ASSERT(!VM_HAS_ERROR(vm), OOPS); \
-    (vm->fiber->error = err);        \
+    (vm->fiber->error = VAR_OBJ(err)); \
   } while (false)
 
 // A doubly link list of vars that have reference in the host application.

--- a/src/include/pocketlang.h
+++ b/src/include/pocketlang.h
@@ -30,7 +30,7 @@ extern "C" {
 // String representation of the version.
 #define PK_VERSION_STRING "0.1.0"
 
-// Pocketlang visibility macros. define PK_DLL for using pocketlang as a 
+// Pocketlang visibility macros. define PK_DLL for using pocketlang as a
 // shared library and define PK_COMPILE to export symbols when compiling the
 // pocketlang it self as a shared library.
 
@@ -264,7 +264,7 @@ PK_PUBLIC void pkRegisterBuiltinFn(PKVM* vm, const char* name, pkNativeFn fn,
 // the last character of the path **must** be a path seperator '/' or '\\'.
 PK_PUBLIC void pkAddSearchPath(PKVM* vm, const char* path);
 
-// Invoke pocketlang's allocator directly.  This function should be called 
+// Invoke pocketlang's allocator directly.  This function should be called
 // when the host application want to send strings to the PKVM that are claimed
 // by the VM once the caller returned it. For other uses you **should** call
 // pkRealloc with [size] 0 to cleanup, otherwise there will be a memory leak.
@@ -340,6 +340,12 @@ PK_PUBLIC void pkSetRuntimeError(PKVM* vm, const char* message);
 
 // Set a runtime error with C formated string.
 PK_PUBLIC void pkSetRuntimeErrorFmt(PKVM* vm, const char* fmt, ...);
+
+// Set a runtime error object at slot.
+PK_PUBLIC void pkSetRuntimeErrorObj(PKVM* vm, int slot);
+
+// Get the runtime error of VM at [slot].
+PK_PUBLIC void pkGetRuntimeError(PKVM* vm, int slot);
 
 // Returns native [self] of the current method as a void*.
 PK_PUBLIC void* pkGetSelf(const PKVM* vm);

--- a/src/libs/gen/nativeapi.h
+++ b/src/libs/gen/nativeapi.h
@@ -30,6 +30,8 @@ typedef PkResult (*pkRunString_t)(PKVM*, const char*);
 typedef PkResult (*pkRunFile_t)(PKVM*, const char*);
 typedef PkResult (*pkRunREPL_t)(PKVM*);
 typedef void (*pkSetRuntimeError_t)(PKVM*, const char*);
+typedef void (*pkSetRuntimeErrorObj_t)(PKVM*, int);
+typedef void (*pkGetRuntimeError_t)(PKVM*, int);
 typedef void* (*pkGetSelf_t)(const PKVM*);
 typedef int (*pkGetArgc_t)(const PKVM*);
 typedef bool (*pkCheckArgcRange_t)(PKVM*, int, int, int);
@@ -90,6 +92,8 @@ typedef struct {
   pkRunFile_t pkRunFile_ptr;
   pkRunREPL_t pkRunREPL_ptr;
   pkSetRuntimeError_t pkSetRuntimeError_ptr;
+  pkSetRuntimeErrorObj_t pkSetRuntimeErrorObj_ptr;
+  pkGetRuntimeError_t pkGetRuntimeError_ptr;
   pkGetSelf_t pkGetSelf_ptr;
   pkGetArgc_t pkGetArgc_ptr;
   pkCheckArgcRange_t pkCheckArgcRange_ptr;
@@ -164,6 +168,8 @@ PkNativeApi pkMakeNativeAPI() {
   api.pkRunFile_ptr = pkRunFile;
   api.pkRunREPL_ptr = pkRunREPL;
   api.pkSetRuntimeError_ptr = pkSetRuntimeError;
+  api.pkSetRuntimeErrorObj_ptr = pkSetRuntimeErrorObj;
+  api.pkGetRuntimeError_ptr = pkGetRuntimeError;
   api.pkGetSelf_ptr = pkGetSelf;
   api.pkGetArgc_ptr = pkGetArgc;
   api.pkCheckArgcRange_ptr = pkCheckArgcRange;

--- a/tests/lang/try.pk
+++ b/tests/lang/try.pk
@@ -1,0 +1,145 @@
+def test1
+  isRaise = fn(flag)
+    if flag then raise("NOT OK") end
+    return "OK"
+  end
+
+  fiber = Fiber(isRaise)
+  result = fiber.try(false)
+  assert(result == "OK")
+  assert(fiber.error == null)
+
+  fiber = Fiber(isRaise)
+  result = fiber.try(true)
+  assert(result == null)
+  assert(fiber.error == "NOT OK")
+end
+
+class Error
+  def _init(msg) self.msg = msg end
+  def _str() return "Error: " + self.msg end
+end
+
+def run(f1)
+  fiber = Fiber(f1)
+  result = fiber.run()
+  if not fiber.error then return result end
+end
+
+def try(f1)
+  fiber = Fiber(f1)
+  result = fiber.try()
+  if not fiber.error then return result end
+end
+
+def tryExcept(f1, f2)
+  fiber = Fiber(f1)
+  result = fiber.try()
+  if fiber.error
+    if f2.arity == 0 then f2()
+    else f2(Error(fiber.error)) end
+    return
+  end
+  return result
+end
+
+def tryExceptFinally(f1, f2, f3)
+  fiber = Fiber(f1)
+  result = fiber.try()
+  if fiber.error
+    if f2.arity == 0 then f2()
+    else f2(Error(fiber.error)) end
+    f3()
+    return
+  end
+  f3()
+  return result
+end
+
+def test2
+  try fn # ignore error
+    raise("some error")
+  end
+
+  result = ""
+  tryExcept(fn
+    raise("some error")
+    result += "Try"
+
+  end, fn(err) # except
+    assert(err is Error)
+    assert(err.msg == "some error")
+    result += "Except"
+
+  end) # finally
+  assert(result == "Except")
+
+  result = ""
+  tryExceptFinally(fn
+    raise("some error")
+    result += "Try"
+
+  end, fn(err) # except
+    assert(err is Error)
+    assert(err.msg == "some error")
+    result += "Except"
+
+  end, fn # finally
+    result += "Finally"
+  end)
+  assert(result == "ExceptFinally")
+
+  result = ""
+  tryExceptFinally(fn
+    result += "Try"
+  end, fn
+    result += "Except"
+  end, fn
+    result += "Finally"
+  end)
+  assert(result == "TryFinally")
+
+end
+
+def test3
+  result = ""
+  try fn
+    run fn
+      run fn
+        run fn
+          result += "1"
+          raise()
+          print("")
+        end
+        result += "2" # UNREACHABLE
+      end
+      result += "3" # UNREACHABLE
+    end
+    result += "4" # UNREACHABLE
+  end
+  assert(result == "1")
+
+  result = ""
+  try fn
+    run fn
+      try fn
+        run fn
+          result += "1"
+          raise()
+        end
+        result += "2" # UNREACHABLE
+      end
+      result += "3"
+      raise()
+    end
+    result += "4" # UNREACHABLE
+  end
+  assert(result == "13")
+end
+
+test1()
+test2()
+test3()
+
+# If we got here, that means all test were passed.
+print('All TESTS PASSED')

--- a/tests/native/dl/pknative.c
+++ b/tests/native/dl/pknative.c
@@ -27,6 +27,8 @@ typedef PkResult (*pkRunString_t)(PKVM*, const char*);
 typedef PkResult (*pkRunFile_t)(PKVM*, const char*);
 typedef PkResult (*pkRunREPL_t)(PKVM*);
 typedef void (*pkSetRuntimeError_t)(PKVM*, const char*);
+typedef void (*pkSetRuntimeErrorObj_t)(PKVM*, int);
+typedef void (*pkGetRuntimeError_t)(PKVM*, int);
 typedef void* (*pkGetSelf_t)(const PKVM*);
 typedef int (*pkGetArgc_t)(const PKVM*);
 typedef bool (*pkCheckArgcRange_t)(PKVM*, int, int, int);
@@ -87,6 +89,8 @@ typedef struct {
   pkRunFile_t pkRunFile_ptr;
   pkRunREPL_t pkRunREPL_ptr;
   pkSetRuntimeError_t pkSetRuntimeError_ptr;
+  pkSetRuntimeErrorObj_t pkSetRuntimeErrorObj_ptr;
+  pkGetRuntimeError_t pkGetRuntimeError_ptr;
   pkGetSelf_t pkGetSelf_ptr;
   pkGetArgc_t pkGetArgc_ptr;
   pkCheckArgcRange_t pkCheckArgcRange_ptr;
@@ -150,6 +154,8 @@ PK_EXPORT void pkInitApi(PkNativeApi* api) {
   pk_api.pkRunFile_ptr = api->pkRunFile_ptr;
   pk_api.pkRunREPL_ptr = api->pkRunREPL_ptr;
   pk_api.pkSetRuntimeError_ptr = api->pkSetRuntimeError_ptr;
+  pk_api.pkSetRuntimeErrorObj_ptr = api->pkSetRuntimeErrorObj_ptr;
+  pk_api.pkGetRuntimeError_ptr = api->pkGetRuntimeError_ptr;
   pk_api.pkGetSelf_ptr = api->pkGetSelf_ptr;
   pk_api.pkGetArgc_ptr = api->pkGetArgc_ptr;
   pk_api.pkCheckArgcRange_ptr = api->pkCheckArgcRange_ptr;
@@ -265,6 +271,14 @@ PkResult pkRunREPL(PKVM* vm) {
 
 void pkSetRuntimeError(PKVM* vm, const char* message) {
   pk_api.pkSetRuntimeError_ptr(vm, message);
+}
+
+void pkSetRuntimeErrorObj(PKVM* vm, int slot) {
+  pk_api.pkSetRuntimeErrorObj_ptr(vm, slot);
+}
+
+void pkGetRuntimeError(PKVM* vm, int slot) {
+  pk_api.pkGetRuntimeError_ptr(vm, slot);
 }
 
 void* pkGetSelf(const PKVM* vm) {


### PR DESCRIPTION
Basic error handling via fiber. Example:
```ruby
fb = Fiber fn
  [][1]
end

fb.try()
if fb.error
  print(fb.error)
else
  print("OK")
end
```

Output:
```
List index out of bound.
```

Also fix following bug:
```ruby
1.times fn (i)
  1.times fn (i)
    [][1]
  end
end
assert(false) # should be unreachable
```

Output before this patch:
```
Error: List index out of bound.
  @func() [/workspace/pocketlang/build/test.pk:3]
Error: Assertion failed.
  @main() [/workspace/pocketlang/build/test.pk:6]
```

After this patch:
```
Error: List index out of bound.
  @func() [/workspace/pocketlang/build/test.pk:3]
  @func() [/workspace/pocketlang/build/test.pk:4]
  @main() [/workspace/pocketlang/build/test.pk:5]
```

Traditional `try, except, finally` can be emulated. Example: ```tests/lang/try.pk```.
