### PR TITLE
[Design] add copy constructor of List and Map (BREAKING)

### DIFF
--- a/src/core/core.c
+++ b/src/core/core.c
@@ -947,6 +947,8 @@ static void _ctorList(PKVM* vm) {
     } else {
       RET_ERR(newString(vm, "Expected a natural number or a list."));
     }
+  } else {
+    list = newList(vm, 0);
   }
   RET(VAR_OBJ(list));
 }

--- a/src/core/core.c
+++ b/src/core/core.c
@@ -931,17 +931,39 @@ static void _ctorString(PKVM* vm) {
 }
 
 static void _ctorList(PKVM* vm) {
-  List* list = newList(vm, ARGC);
-  vmPushTempRef(vm, &list->_super); // list.
-  for (int i = 0; i < ARGC; i++) {
-    listAppend(vm, list, ARG(i + 1));
+  if (!pkCheckArgcRange(vm, ARGC, 0, 1)) return;
+  List* list;
+  int64_t natural;
+
+  if (ARGC == 1) {
+    if (isInteger(ARG(1), &natural) && natural >= 0) {
+      list = newList(vm, natural);
+      list->elements.count = natural;
+
+    } else if (IS_OBJ_TYPE(ARG(1), OBJ_LIST)) {
+      List* src_list = (List*) AS_OBJ(ARG(1));
+      list = listAdd(vm, src_list, NULL);
+
+    } else {
+      RET_ERR(newString(vm, "Expected a natural number or a list."));
+    }
   }
-  vmPopTempRef(vm); // list.
   RET(VAR_OBJ(list));
 }
 
 static void _ctorMap(PKVM* vm) {
-  RET(VAR_OBJ(newMap(vm)));
+  if (!pkCheckArgcRange(vm, ARGC, 0, 1)) return;
+  Map* map;
+
+  if (ARGC == 1) {
+    Map* src_map;
+    if (!validateArgMap(vm, 1, &src_map)) return;
+    map = mapDup(vm, src_map);
+
+  } else {
+    map = newMap(vm);
+  }
+  RET(VAR_OBJ(map));
 }
 
 static void _ctorRange(PKVM* vm) {
@@ -1432,7 +1454,7 @@ static void initializePrimitiveClasses(PKVM* vm) {
   ADD_CTOR(PK_STRING, "@ctorString", _ctorString, -1);
   ADD_CTOR(PK_RANGE,  "@ctorRange",  _ctorRange,   2);
   ADD_CTOR(PK_LIST,   "@ctorList",   _ctorList,   -1);
-  ADD_CTOR(PK_MAP,    "@ctorMap",    _ctorMap,     0);
+  ADD_CTOR(PK_MAP,    "@ctorMap",    _ctorMap,    -1);
   ADD_CTOR(PK_FIBER,  "@ctorFiber",  _ctorFiber,   1);
 #undef ADD_CTOR
 

--- a/src/core/value.h
+++ b/src/core/value.h
@@ -733,6 +733,9 @@ void mapClear(PKVM* vm, Map* self);
 // otherwise return VAR_UNDEFINED.
 Var mapRemoveKey(PKVM* vm, Map* self, Var key);
 
+// Duplicate a map.
+Map* mapDup(PKVM* vm, Map* self);
+
 // Returns true if the fiber has error, and if it has any the fiber cannot be
 // resumed anymore.
 bool fiberHasError(Fiber* fiber);


### PR DESCRIPTION
1. List/map constructor can accept a list/map, works as copy constructor.
2. The original list constructor is abandoned, it do the same thing as _list literal_ .
3. List constructor can accept a integer, returns a preallocated list (filling in null).
4. List join (+ operator) should always returned a new list, instead the old one.

Example:
```ruby
l1 = [1, 2, 3]
l2 = l1
l3 = List(l1)
l1[0] = 4
print(l1); print(l2); print(l3)

m1 = {1: 1, 2: 2, 3: 3}
m2 = m1
m3 = Map(m1)
m1[1] = 4
print(m1); print(m2); print(m3)

print(List(3))
```

Output:
```
[4, 2, 3]
[4, 2, 3]
[1, 2, 3]
{2:2, 1:4, 3:3}
{2:2, 1:4, 3:3}
{2:2, 1:1, 3:3}
[null, null, null]
```