### PR TITLE
[Enhancement] modify stringSplit to support \x00 and empty string

### DIFF
--- a/src/core/core.c
+++ b/src/core/core.c
@@ -1068,12 +1068,13 @@ DEF(_stringReplace,
 }
 
 DEF(_stringSplit,
-  "String.split(sep:String) -> List",
+  "String.split([sep:String]) -> List",
   "Split the string into a list of string seperated by [sep] delimeter.") {
 
-  String* sep;
-  if (!validateArgString(vm, 1, &sep)) return;
+  if (!pkCheckArgcRange(vm, ARGC, 0, 1)) return;
+  String* sep = NULL;
 
+  if (ARGC == 1) sep = varToString(vm, ARG(1), false);
   RET(VAR_OBJ(stringSplit(vm, (String*)AS_OBJ(SELF), sep)));
 }
 
@@ -1458,7 +1459,7 @@ static void initializePrimitiveClasses(PKVM* vm) {
   ADD_METHOD(PK_STRING, "upper",   _stringUpper,    0);
   ADD_METHOD(PK_STRING, "find",    _stringFind,    -1);
   ADD_METHOD(PK_STRING, "replace", _stringReplace, -1);
-  ADD_METHOD(PK_STRING, "split",   _stringSplit,    1);
+  ADD_METHOD(PK_STRING, "split",   _stringSplit,   -1);
   ADD_METHOD(PK_STRING, "startswith", _stingStartswith, 1);
   ADD_METHOD(PK_STRING, "endswith", _stingEndswith, 1);
 

--- a/src/core/core.c
+++ b/src/core/core.c
@@ -1074,10 +1074,6 @@ DEF(_stringSplit,
   String* sep;
   if (!validateArgString(vm, 1, &sep)) return;
 
-  if (sep->length == 0) {
-    RET_ERR(newString(vm, "Cannot use empty string as a seperator."));
-  }
-
   RET(VAR_OBJ(stringSplit(vm, (String*)AS_OBJ(SELF), sep)));
 }
 

--- a/src/core/value.c
+++ b/src/core/value.c
@@ -780,7 +780,7 @@ List* stringSplit(PKVM* vm, String* self, String* sep) {
   List* list = newList(vm, 0);
   vmPushTempRef(vm, &list->_super); // list.
 
-  if (sep->length == 0) {
+  if (sep == NULL || sep->length == 0) {
     for (int i = 0; i < self->length; i++) {
       String* ch = newStringLength(vm, &self->data[i], 1);
       vmPushTempRef(vm, &ch->_super); // ch

--- a/src/core/value.h
+++ b/src/core/value.h
@@ -680,8 +680,8 @@ String* stringStrip(PKVM* vm, String* self);
 String* stringReplace(PKVM* vm, String* self,
                       String* old, String* new_, int count);
 
-// Split the string into a list of string separated by [sep]. String [sep] must
-// not be of length 0 otherwise an assertion will fail.
+// Split the string into a list of string separated by [sep].
+// If [sep] == "", split string into characters.
 List* stringSplit(PKVM* vm, String* self, String* sep);
 
 // Creates a new string from the arguments. This is intended for internal


### PR DESCRIPTION
1. String in pocketlang could be include \x00, but String.split() don't.
2. If [sep] is empty, split string into characters.
3. String.split should be the opposite of List.join perfectly.

Example:
```ruby
print("a\x00b\x00c".split('\x00'))
print("abcde".split())
```

Output:
```
["a", "b", "c"]
["a", "b", "c", "d", "e"]
```