### PR TITLE
access class and instance attribs by '_attr'

### DIFF
--- a/src/core/core.c
+++ b/src/core/core.c
@@ -1977,6 +1977,18 @@ Var varGetAttrib(PKVM* vm, Var on, String* attrib) {
   }
 
   Object* obj = AS_OBJ(on);
+
+  if (attrib->hash == CHECK_HASH("_attr", 0x89ec270d)) {
+    switch (obj->type) {
+      case OBJ_CLASS:
+        Class* cls = (Class*) obj;
+        return VAR_OBJ(cls->static_attribs);
+      case OBJ_INST:
+        Instance* inst = (Instance*) obj;
+        return VAR_OBJ(inst->attribs);
+    }
+  }
+
   switch (obj->type) {
     case OBJ_STRING: {
       String* str = (String*)obj;


### PR DESCRIPTION
Allow following code:
```rb
class Foo
  def []=(key, value)
    self._attr[key] = value
  end
end

f = Foo()
f["a" + "b"] = 123

assert(f.ab == 123)
```

Moreover, maybe `@getter` and `@setter` can be renamed to `_getter` and `_setter`.
Don't need to limit them be used in native module only.

```rb
class Foo
  def _getter(key)
    # do someing...
    return self._attr[key]
  end

  def _setter(key, value)
    # do someing...
    self._attr[key] = value
  end
end
```

