### PR TITLE
[Bugfix] fix compiler bug that cause crash when parsing 1!

### DIFF
--- a/src/core/compiler.c
+++ b/src/core/compiler.c
@@ -1649,7 +1649,7 @@ GrammarRule rules[] = {  // Prefix       Infix             Infix Precedence
   /* TK_IS         */ { NULL,          exprBinaryOp,     PREC_TEST },
   /* TK_AND        */ { NULL,          exprAnd,          PREC_LOGICAL_AND },
   /* TK_OR         */ { NULL,          exprOr,           PREC_LOGICAL_OR },
-  /* TK_NOT        */ { exprUnaryOp,   NULL,             PREC_UNARY },
+  /* TK_NOT        */ { exprUnaryOp,   NULL,             NO_INFIX },
   /* TK_TRUE       */ { exprValue,     NULL,             NO_INFIX },
   /* TK_FALSE      */ { exprValue,     NULL,             NO_INFIX },
   /* TK_SELF       */ { exprSelf,      NULL,             NO_INFIX },


### PR DESCRIPTION
Fix a small bug I found in `compiler.c`.