### PR TITLE
[Design] variale number of arguments and default values

### DIFF
--- a/src/core/vm.c
+++ b/src/core/vm.c
@@ -1280,12 +1280,10 @@ L_do_call:
       // If we reached here it's a valid callable.
       ASSERT(closure != NULL, OOPS);
 
-      // -1 argument means multiple number of args.
-      if (closure->fn->arity != -1 && closure->fn->arity != argc) {
-        char buff[STR_INT_BUFF_SIZE]; sprintf(buff, "%d", closure->fn->arity);
-        String* msg = stringFormat(vm, "Expected exactly $ argument(s) "
-                                  "for function $", buff, closure->fn->name);
-        RUNTIME_ERROR(msg);
+      // Like lua: Extra arguments are thrown away; extra parameters get null.
+      while (closure->fn->arity != -1 && closure->fn->arity > argc) {
+        PUSH(VAR_NULL);
+        argc++;
       }
 
       if (closure->fn->is_native) {

--- a/src/core/vm.c
+++ b/src/core/vm.c
@@ -1281,9 +1281,14 @@ L_do_call:
       ASSERT(closure != NULL, OOPS);
 
       // Like lua: Extra arguments are thrown away; extra parameters get null.
-      while (closure->fn->arity != -1 && closure->fn->arity > argc) {
-        PUSH(VAR_NULL);
-        argc++;
+      if (closure->fn->arity != -1) {
+        if (argc > closure->fn->arity) { // adjust stack
+          fiber->sp -= argc - closure->fn->arity;
+        }
+        while (closure->fn->arity > argc) {
+          PUSH(VAR_NULL);
+          argc++;
+        }
       }
 
       if (closure->fn->is_native) {


### PR DESCRIPTION
Change the callable behavior: "extra arguments are thrown away; extra parameters get null" (like lua).
Moreover, parameters can have default value,  even if the default value is an expression.

Example:
```ruby
def foo
  return "hello"
end

def test(a = 10, b = a * 2, c = foo())
  print(c, a, b)
end

test()
test(0)
test(5)
test(5, 100)
test(5, null, "hi")
```

Output:
```
hello 10 20
hello 0 0
hello 5 10
hello 5 100
hi 5 10
```