### PR TITLE
class instance can be callable by adding _call method

### DIFF
--- a/src/core/core.h
+++ b/src/core/core.h
@@ -18,6 +18,7 @@
 #define LITS__init      "_init"
 #define LITS__str       "_str"
 #define LITS__repr      "_repr"
+#define LITS__call      "_call"
 
 // Functions, methods, classes and  other names which are intrenal / special to
 // pocketlang are starts with the following character (ex: @main, @literalFn).


### PR DESCRIPTION
Example to create a callable object:
```ruby
class Foo
  def _call()
    print('1')
  end
end

foo = Foo()
foo()
```