### PR TITLE
[Bugfix] native class can be inherited in script

### DIFF
--- a/src/core/value.c
+++ b/src/core/value.c
@@ -553,10 +553,13 @@ Instance* newInstance(PKVM* vm, Class* cls) {
   vmPushTempRef(vm, &inst->_super); // inst.
 
   inst->cls = cls;
-  if (cls->new_fn != NULL) {
-    inst->native = cls->new_fn(vm);
-  } else {
-    inst->native = NULL;
+  inst->native = NULL;
+  while (cls != NULL) {
+    if (cls->new_fn != NULL) {
+      inst->native = cls->new_fn(vm);
+      break;
+    }
+    cls = cls->super_class;
   }
 
   inst->attribs = newMap(vm);

--- a/src/core/value.c
+++ b/src/core/value.c
@@ -1223,9 +1223,15 @@ void freeObject(PKVM* vm, Object* self) {
 
     case OBJ_INST: {
       Instance* inst = (Instance*)self;
-      if (inst->cls->delete_fn != NULL) {
-        inst->cls->delete_fn(vm, inst->native);
+      Class* cls = inst->cls;
+      while (cls != NULL) {
+        if (cls->delete_fn != NULL) {
+          cls->delete_fn(vm, inst->native);
+          break;
+        }
+        cls = cls->super_class;
       }
+
       DEALLOCATE(vm, inst, Instance);
       return;
     }


### PR DESCRIPTION
Example:
```ruby
from types import Vector

class Vector2 is Vector
  def *=(n)
    self.x *= n; self.y *= n; self.z *= n
    return self
  end
end

v = Vector2(1, 2, 3)
v *= 2
print(v)
```

Output:
```
[2, 4, 6]
```