### PR TITLE
[Enhancement] add iterator protocol for object

### DIFF
--- a/src/core/compiler.c
+++ b/src/core/compiler.c
@@ -3187,10 +3187,9 @@ static void compileForStatement(Compiler* compiler) {
   compileExpression(compiler);
   compiler->can_define = can_define;
 
-  // Add iterator to locals. It's an increasing integer indicating that the
-  // current loop is nth starting from 0.
+  // Add iterator to locals and initialize it to null.
   compilerAddVariable(compiler, "@iterator", 9, iter_line); // Iterator.
-  emitOpcode(compiler, OP_PUSH_0);
+  emitOpcode(compiler, OP_PUSH_NULL);
 
   // Add the iteration value. It'll be updated to each element in an array of
   // each character in a string etc.

--- a/src/core/core.c
+++ b/src/core/core.c
@@ -2555,10 +2555,10 @@ bool varIterate(PKVM* vm, Var seq, Var* iterator, Var* value) {
 
     case OBJ_INST: {
       for(;;) {
-        if (!_callBinaryOpMethod(vm, seq, *iterator, "iterate", iterator)) break;
+        if (!_callBinaryOpMethod(vm, seq, *iterator, LITS__next, iterator)) break;
         if (IS_NULL(*iterator)) return false;
 
-        if (!_callBinaryOpMethod(vm, seq, *iterator, "iteratorValue", value)) break;
+        if (!_callBinaryOpMethod(vm, seq, *iterator, LITS__value, value)) break;
         return true;
       }
       goto _default;

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -149,4 +149,8 @@ Var varGetSubscript(PKVM* vm, Var on, Var key);
 // Set subscript [value] with the [key] (ie. on[key] = value).
 void varsetSubscript(PKVM* vm, Var on, Var key, Var value);
 
+// Iterate over [seq] store as [value], [iterator] start with null.
+// Returns ture to continue loop, false to break.
+bool varIterate(PKVM* vm, Var seq, Var* iterator, Var* value);
+
 #endif // PK_CORE_H

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -18,6 +18,8 @@
 #define LITS__init      "_init"
 #define LITS__str       "_str"
 #define LITS__repr      "_repr"
+#define LITS__next      "_next"
+#define LITS__value     "_value"
 
 // Functions, methods, classes and  other names which are intrenal / special to
 // pocketlang are starts with the following character (ex: @main, @literalFn).


### PR DESCRIPTION
Object can be used as iterator if _next and _value is defined. Similar to [wren's iterator protocal](https://wren.io/control-flow.html). Example 1: 
```ruby
class Countup
  def _init(first, last, step)
    self.first = first
    self.last = last
    self.step = step
  end

  def _next(iter)
    if iter == null then return self.first end
    iter += self.step
    if iter > self.last then iter = null end
    return iter
  end

  def _value(iter)
    return iter
  end
end

for i in Countup(0, 10, 2)
  print(i)
end
```

Output:
```
0
2
4
6
8
10
```

Example 2:
```ruby
class Node
  def _init(val)
    self.val = val
    self.next = null
  end

  def _str()
    return "(${self.val})"
  end
end

class LinkedList
  def _init()
    self.head = null
  end

  def append(node)
    if self.head == null
      self.head = node
    else
      last = self.head
      while last.next do last = last.next end
      last.next = node
    end
  end

  def _next(iter)
    if iter == null then return self.head end
    return iter.next
  end

  def _value(iter)
    return iter
  end
end

ll = LinkedList()
ll.append(Node(4))
ll.append(Node(6))
ll.append(Node(3))
ll.append(Node(9))

for n in ll
  print(n)
end
```

Output:
```
(4)
(6)
(3)
(9)
```

Example 3:
```ruby
class StringIter
  def _init(text)
    self.text = text
  end

  def _next(iter)
    if iter == null then return 0 end
    iter += 1
    if iter >= self.text.length then iter = null end
    return iter
  end

  def _value(iter)
    return self.text[iter]
  end
end

for c in StringIter("hello")
  print(c)
end
```

Output:
```
h
e
l
l
o
```