### PR TITLE
Store class in closures to allow super super calls

### DIFF
--- a/src/core/core.c
+++ b/src/core/core.c
@@ -1590,11 +1590,11 @@ Var getMethod(PKVM* vm, Var self, String* name, bool* is_method) {
   return varGetAttrib(vm, self, name);
 }
 
-Closure* getSuperMethod(PKVM* vm, Var self, String* name) {
-  Class* super = getClass(vm, self)->super_class;
+Closure* getSuperMethod(PKVM* vm, Class* class, String* name) {
+  Class* super = NULL == class ? NULL : class->super_class;
   if (super == NULL) {
-    VM_SET_ERROR(vm, stringFormat(vm, "'$' object has no parent class.", \
-                 varTypeName(self)));
+    VM_SET_ERROR(vm, stringFormat(vm, "'$' has no parent class.", \
+                 class->name));
     return NULL;
   };
 

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -89,7 +89,7 @@ Var getMethod(PKVM* vm, Var self, String* name, bool* is_method);
 
 // Returns the method (closure) from the instance's super class. If the method
 // doesn't exists, it'll set an error on the VM.
-Closure* getSuperMethod(PKVM* vm, Var self, String* name);
+Closure* getSuperMethod(PKVM* vm, Class* class, String* name);
 
 // Unlike getMethod this will not set error and will not try to get attribute
 // with the same name. It'll return true if the method exists on [self], false

--- a/src/core/public.c
+++ b/src/core/public.c
@@ -306,6 +306,7 @@ void pkClassAddMethod(PKVM* vm, PkHandle* cls,
   // won't be garbage collected (class handle has reference to the module).
 
   Closure* method = newClosure(vm, fn);
+  method->class = class_;
   vmPopTempRef(vm); // fn.
   vmPushTempRef(vm, &method->_super); // method.
   {

--- a/src/core/value.h
+++ b/src/core/value.h
@@ -402,6 +402,7 @@ struct Function {
 struct Closure {
   Object _super;
 
+  Class* class;
   Function* fn;
   Upvalue* upvalues[DYNAMIC_TAIL_ARRAY];
 };

--- a/tests/lang/class.pk
+++ b/tests/lang/class.pk
@@ -246,7 +246,20 @@ class B is A
   end
 end
 
+class C is B
+  def _init()
+    super()
+    print("C init")
+  end
+  def foo()
+    print("C foo")
+    return super.foo()
+  end
+end
+
 b = B()
 assert(b.foo() == "A.bar")
+c = C()
+assert(c.foo() == "A.bar")
 
 print('ALL TESTS PASSED')


### PR DESCRIPTION
This changes how the parent class is found when doing `super` calls.  It now uses the parent class of the function that the `super` call appears in, rather than the immediate parent of `self`.  This means that you can use `super` in functions that are themselves called using `super`.